### PR TITLE
Remove manual AMBuild version check

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -28,13 +28,6 @@ except:
 		sys.stderr.write('AMBuild must be installed to build this project.\n')
 		sys.stderr.write('http://www.alliedmods.net/ambuild\n')
 	sys.exit(1)
-from pkg_resources import parse_version
-
-# Hack to show a decent upgrade message, which wasn't done until 2.2.
-ambuild_version = parse_version(getattr(run, 'CURRENT_API', '2.1'))
-if ambuild_version < parse_version("2.2.1"):
-	sys.stderr.write("AMBuild 2.2.1 or higher is required; please update\n")
-	sys.exit(1)
 
 parser = run.BuildParser(sourcePath=sys.path[0], api='2.2')
 parser.options.add_argument('--enable-debug', action='store_true', default = True, dest='debug',


### PR DESCRIPTION
For whatever reason SM mock CI blew up
https://github.com/alliedmodders/sourcemod/actions/runs/22438114816/job/64975579601

It's probably some python version thing again, or maybe CI build image. I don't think it's worth a full scale investigation, let's just remove the problematic code and call it a day.

I know the intent is to display a clean error message, but you've had a check for API version for as long as AMBuild 2.0 existed so let's rely on that
https://github.com/alliedmodders/ambuild/blob/557138e6a3adb4a61a79183c46acca8473da8440/ambuild2/run.py#L101L105

So in any case an exception will be thrown by
https://github.com/alliedmodders/hl2sdk-mock/blob/cf6e7e0386fb4449a369771a366f0c227402944e/configure.py#L32

Which will be good enough imo as an error message.